### PR TITLE
add env BYPASS_PATH

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -35,9 +35,11 @@ class Main {
 
     function startLanguageServer() {
         var serverModule = context.asAbsolutePath("./server_wrapper.js");
+        var env = js.Node.process.env; 
+        if (env['BYPASS_PATH'] != null) env['PATH'] = env['BYPASS_PATH'];
         var serverOptions = {
-            run: {module: serverModule, options: {env: js.Node.process.env}},
-            debug: {module: serverModule, options: {env: js.Node.process.env, execArgv: ["--nolazy", "--debug=6004"]}}
+            run: {module: serverModule, options: {env: env}},
+            debug: {module: serverModule, options: {env: env, execArgv: ["--nolazy", "--debug=6004"]}}
         };
         var clientOptions = {
             documentSelector: "haxe",


### PR DESCRIPTION
.. to optionally pass actual environment PATH variable to language server, since vscode doesn't seem to like modified PATHs.
